### PR TITLE
responsive para controles input y select

### DIFF
--- a/core/builder/controleshtml/InputBootstrap.class.php
+++ b/core/builder/controleshtml/InputBootstrap.class.php
@@ -57,17 +57,28 @@ class InputBootstrap extends HtmlBase {
         $this->cadenaHTML .= '">';
 
         if (isset($this->atributos[self::ETIQUETA]) && $this->atributos[self::ETIQUETA] != "") {
-
-            $this->cadenaHTML .= '<label for="';
-            $this->cadenaHTML .= $this->atributos['id'];
-            $this->cadenaHTML .= '" class="col-xs-';
-            $this->cadenaHTML .= $this->atributos['anchoEtiqueta'];
-            $this->cadenaHTML .= ' col-form-label">';
+        	//Manejo de responsiveness
+        	$relacion= $this->atributos['anchoEtiqueta']*100/12;
+        	$estiloLabel='';
+        	$estiloControl='';
+        	 
+        	// Para xs = extra small screens (mobile phones)
+        	if($relacion<33){
+        		$estiloLabel.='col-xs-12 ';
+        		$estiloControl.='col-xs-12 ';
+        	}else{
+        		$estiloLabel.='col-xs-'.$this->atributos['anchoEtiqueta'].' ';
+        		$estiloControl.='col-xs-'.$this->atributos['anchoCaja'].' ';
+        	}
+        	$estiloLabel.='col-sm-'.$this->atributos['anchoEtiqueta'].' col-md-'.$this->atributos['anchoEtiqueta'].' col-lg-'.$this->atributos['anchoEtiqueta'];
+        	$estiloControl.='col-sm-'.$this->atributos['anchoCaja'].' col-md-'.$this->atributos['anchoCaja'].' col-lg-'.$this->atributos['anchoCaja'];
+        	 
+        	//Fin manejo de responsiveness
+        	
+            $this->cadenaHTML .= '<label for="'. $this->atributos['id'].'" class="'.$estiloLabel.' col-form-label">';
             $this->cadenaHTML .= $this->atributos['etiqueta'];
             $this->cadenaHTML .= '</label>';
-            $this->cadenaHTML .= '<div class="col-xs-';
-            $this->cadenaHTML .= $this->atributos['anchoCaja'];
-            $this->cadenaHTML .= '">';
+            $this->cadenaHTML .= '<div class="'.$estiloControl.'">';
 
         }
 

--- a/core/builder/controleshtml/SelectBootstrap.class.php
+++ b/core/builder/controleshtml/SelectBootstrap.class.php
@@ -65,19 +65,30 @@ class SelectBootstrap extends HtmlBase {
 //         }
 
 //         $this->cadenaHTML .= $this->etiqueta($atributos);
-        
+
+    	//Manejo de responsiveness
+    	$relacion= $this->atributos['anchoEtiqueta']*100/12;    	
+    	$estiloLabel='';
+    	$estiloControl='';    	
+    	
+    	// Para xs = extra small screens (mobile phones)
+    	if($relacion<33){    	
+    		$estiloLabel.='col-xs-12 ';
+    		$estiloControl.='col-xs-12 ';    		
+    	}else{
+    		$estiloLabel.='col-xs-'.$this->atributos['anchoEtiqueta'].' ';
+    		$estiloControl.='col-xs-'.$this->atributos['anchoCaja'].' ';
+    	}
+    	$estiloLabel.='col-sm-'.$this->atributos['anchoEtiqueta'].' col-md-'.$this->atributos['anchoEtiqueta'].' col-lg-'.$this->atributos['anchoEtiqueta'];
+    	$estiloControl.='col-sm-'.$this->atributos['anchoCaja'].' col-md-'.$this->atributos['anchoCaja'].' col-lg-'.$this->atributos['anchoCaja'];
+    	
+    	//Fin manejo de responsiveness
+    	
         $this->cadenaHTML .= '<div class="form-group row">';
-        $this->cadenaHTML .= '<label for="';
-        $this->cadenaHTML .= $this->atributos['id'];
-        $this->cadenaHTML .= '" class="col-xs-';
-        $this->cadenaHTML .= $this->atributos['anchoEtiqueta'];
-        $this->cadenaHTML .= ' col-form-label">';
+        $this->cadenaHTML .= '<label for="'.$this->atributos['id'].'" class="'.$estiloLabel.' col-form-label">';
         $this->cadenaHTML .= $this->atributos['etiqueta'];
         $this->cadenaHTML .= '</label>';
-        $this->cadenaHTML .= '<div class="col-xs-';
-        $this->cadenaHTML .= $this->atributos['anchoCaja'];
-        $this->cadenaHTML .= '">';
-        
+        $this->cadenaHTML .= '<div class="'.$estiloControl.'">';        
         $this->cadenaHTML .= $this->cuadro_lista($atributos);
         $this->cadenaHTML .= "</div>\n";
         $this->cadenaHTML .= "</div>\n";


### PR DESCRIPTION
Revisar por favor. Cuando la relación entre el tamaño de la etiqueta y el control es inferior al 33% entonces la etiqueta se coloca en una línea aparte en los dispositivos xs. Se agregan los otros tamaños solo para posibles mejoras futuras.